### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,3 @@
-baseURL = 'https://mirio.dev'
 languageCode = 'en-us'
 title = "cole's blog"
 


### PR DESCRIPTION
Using `baseURL` causes the Cloudflare Pages build Previews to link away from the preview domains when navigating the preview